### PR TITLE
Downgrade to spark-2.4.1 for compatibility with graphframes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PYSPARK_PYTHON=python3
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential\
+	apt-get install -y --no-install-recommends build-essential\
 	expect git vim zip unzip wget openjdk-8-jdk wget sudo
 RUN apt-get install -y python3 python3-pip
 
@@ -16,10 +16,10 @@ RUN apt-get install -y python3 python3-pip
 
 # Download and install spark
 RUN	cd /usr/local/ &&\
-    wget "http://apache.cs.utah.edu/spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz" &&\
-	tar -xvzf spark-2.4.2-bin-hadoop2.7.tgz && \
-	ln -s ./spark-2.4.2-bin-hadoop2.7 spark &&  \
-	rm -rf /usr/local/spark-2.4.2-bin-hadoop2.7.tgz && \
+	wget "https://archive.apache.org/dist/spark/spark-2.4.1/spark-2.4.1-bin-hadoop2.7.tgz" &&\
+	tar -xvzf spark-2.4.1-bin-hadoop2.7.tgz && \
+	ln -s ./spark-2.4.1-bin-hadoop2.7 spark &&  \
+	rm -rf /usr/local/spark-2.4.1-bin-hadoop2.7.tgz && \
 	rm -rf /usr/local/spark/external && \
 	chmod a+rwx -R /usr/local/spark/
 RUN pip3 install numpy


### PR DESCRIPTION
The recent upgrade to Spark 2.4.2 made the prepared Docker image incompatible to [`graphframes`](https://github.com/graphframes/graphframes) which is used in Part A & C.  
Spark 2.4.2 upgraded from Scala 2.11 to 2.12, which is not yet supported by `graphframes` (https://github.com/graphframes/graphframes/issues/331).

This can result in errors similar to: 
```
java.lang.NoSuchMethodError: scala.Predef$.refArrayOps([Ljava/lang/Object;)Lscala/collection/mutable/ArrayOps
```

### Comparison:

```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.4.2
      /_/

Using Scala version 2.12.8 (OpenJDK 64-Bit Server VM, Java 1.8.0_191)
```

vs.

```
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 2.4.1
      /_/

Using Scala version 2.11.12 (OpenJDK 64-Bit Server VM, Java 1.8.0_191)
```

